### PR TITLE
Problem: Gyre API dosn't let the caller application decide about errs

### DIFF
--- a/gyre_test.go
+++ b/gyre_test.go
@@ -92,7 +92,9 @@ func testTwoNodes(t *testing.T, port int, wait time.Duration) {
 
 	gyre[0].Shout("GLOBAL", []byte("Hello, World!"))
 
-	if gyre[1].Addr() == "" {
+	if addr, err := gyre[1].Addr(); err != nil {
+		t.Errorf(err.Error())
+	} else if addr == "" {
 		t.Errorf("Addr() shouldn't return empty string")
 	}
 
@@ -136,8 +138,13 @@ func testSyncedHeaders(t *testing.T, n, port int, wait time.Duration) {
 	defer stopNodes(n)
 
 	for i := 0; i < n; i++ {
-		if !reflect.DeepEqual(gyre[i].Headers(), headers[i]) {
-			t.Errorf("expected %v got %v", headers[i], gyre[i].Headers())
+		h, err := gyre[i].Headers()
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+
+		if !reflect.DeepEqual(h, headers[i]) {
+			t.Errorf("expected %v got %v", headers[i], h)
 		}
 	}
 

--- a/node.go
+++ b/node.go
@@ -578,8 +578,14 @@ func (n *node) recvFromPeer(transit msg.Transit) {
 	peer := n.peers[identity]
 
 	if n.verbose {
-		for _, str := range strings.Split(transit.String(), "\n") {
-			if len(str) > 0 {
+		for i, str := range strings.Split(transit.String(), "\n") {
+			if len(str) <= 0 {
+				continue
+			}
+
+			if i == 0 && peer != nil {
+				log.Printf("[%s] %s %s", n.name, peer.name, str)
+			} else {
 				log.Printf("[%s] %s", n.name, str)
 			}
 		}


### PR DESCRIPTION
Solution: Do not call Fatal method pass through the error and the caller
application can deside what to do. Unfortunately this is BC break,
sorry.