### PR TITLE
Continue if ControlMessage is nil.

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -336,14 +336,14 @@ func (b *Beacon) listen() {
 		if b.ipv4Conn != nil {
 			var cm *ipv4.ControlMessage
 			n, cm, _, err = b.ipv4Conn.ReadFrom(buff)
-			if err != nil || n > beaconMax || n == 0 {
+			if err != nil || n > beaconMax || n == 0 || cm == nil {
 				continue
 			}
 			addr = cm.Src
 		} else {
 			var cm *ipv6.ControlMessage
 			n, cm, _, err = b.ipv6Conn.ReadFrom(buff)
-			if err != nil || n > beaconMax || n == 0 {
+			if err != nil || n > beaconMax || n == 0 || cm == nil {
 				continue
 			}
 			addr = cm.Src


### PR DESCRIPTION
There is a circumstance that I can't reliably reproduce where the call to `ReadFrom` in `beacon.go` produces a `nil` instance of a `ControlMessage` without returning an error.

If you look at these sections of the `ipv4` and `ipv6` libraries, you can see that they check to see if `cm != nil`: 
- https://github.com/golang/net/blob/master/ipv4/payload_cmsg.go#L49-L52
- https://github.com/golang/net/blob/master/ipv6/payload_cmsg.go#L39-L42

In `gyre`, this causes a `nil` pointer dereference panic when the situation does arise:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x42c9628]

goroutine 151 [running]:
panic(0x4452de0, 0xc8200100f0)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/zeromq/gyre/beacon.(*Beacon).listen(0xc8203d4210)
	/Users/af/Code/go/src/github.com/zeromq/gyre/beacon/beacon.go:342 +0x4f8
created by github.com/zeromq/gyre/beacon.(*Beacon).start
	/Users/af/Code/go/src/github.com/zeromq/gyre/beacon/beacon.go:213 +0xc8f
exit status 2
```
This is a trivial PR that just checks to make sure the control message is not nil before referencing its `Src` attribute.